### PR TITLE
Fix JDBC pagination for user-ordered queries and DuckDB

### DIFF
--- a/clutch-db-jdbc.el
+++ b/clutch-db-jdbc.el
@@ -830,6 +830,13 @@ Emacs RPC timeout."
   "Return non-nil when CONN is an Oracle JDBC connection."
   (eq (plist-get (clutch-jdbc-conn-params conn) :driver) 'oracle))
 
+(defun clutch-jdbc--duckdb-conn-p (conn)
+  "Return non-nil when CONN is a DuckDB JDBC connection."
+  (let* ((params (clutch-jdbc-conn-params conn))
+         (url (plist-get params :url)))
+    (and (stringp url)
+         (string-prefix-p "jdbc:duckdb:" url))))
+
 (defun clutch-jdbc--clickhouse-conn-p (conn)
   "Return non-nil when CONN is a ClickHouse JDBC connection."
   (eq (plist-get (clutch-jdbc-conn-params conn) :driver) 'clickhouse))
@@ -1090,13 +1097,24 @@ an rn column as a side effect."
 PAGE-NUM is zero-based, and PAGE-SIZE limits each page.  Oracle uses
 ROWNUM subquery syntax compatible with all Oracle versions.  ORDER-BY
 controls the optional sort clause.  PAGE-OFFSET overrides PAGE-NUM
-when non-nil.  Other
-databases use SQL:2011 OFFSET/FETCH (Oracle 12c+, SQL Server 2012+,
-DB2)."
-  (if (clutch-db-sql-has-top-level-limit-p base-sql)
-      base-sql
+when non-nil.  DuckDB JDBC uses LIMIT/OFFSET.  Other databases use
+SQL:2011 OFFSET/FETCH (Oracle 12c+, SQL Server 2012+, DB2)."
+  (cond
+   ((clutch-jdbc--duckdb-conn-p conn)
+    ;; DuckDB is the confirmed JDBC backend that needs LIMIT/OFFSET here.
+    ;; Other JDBC databases may share that dialect family, but keep this
+    ;; branch narrow until they are identified and tested.
+    (clutch-db--build-limit-offset-paged-sql
+     base-sql page-num page-size order-by
+     (lambda (name) (clutch-db-escape-identifier conn name))
+     page-offset))
+   ((clutch-db-sql-has-top-level-limit-p base-sql)
+    base-sql)
+   (t
     (let* ((trimmed (string-trim-right
                      (replace-regexp-in-string ";\\s-*\\'" "" base-sql)))
+           (has-user-order-by
+            (clutch-db-sql-has-top-level-clause-p trimmed "ORDER\\s-+BY"))
            (sortable-sql (if order-by
                              (clutch-db-sql-strip-top-level-order-by trimmed)
                            trimmed))
@@ -1104,13 +1122,15 @@ DB2)."
            (oracle-p (clutch-jdbc--oracle-conn-p conn)))
       (if oracle-p
           (clutch-jdbc--build-oracle-paged-sql conn sortable-sql offset page-size order-by)
-        (let ((order-clause (if order-by
-                                (format " ORDER BY %s %s"
-                                        (clutch-db-escape-identifier conn (car order-by))
-                                        (cdr order-by))
-                              " ORDER BY (SELECT NULL)")))
+        (let ((order-clause (cond
+                             (order-by
+                              (format " ORDER BY %s %s"
+                                      (clutch-db-escape-identifier conn (car order-by))
+                                      (cdr order-by)))
+                             (has-user-order-by "")
+                             (t " ORDER BY (SELECT NULL)"))))
           (format "%s%s OFFSET %d ROWS FETCH NEXT %d ROWS ONLY"
-                  sortable-sql order-clause offset page-size))))))
+                  sortable-sql order-clause offset page-size)))))))
 
 ;;;; SQL dialect methods
 

--- a/test/clutch-db-test.el
+++ b/test/clutch-db-test.el
@@ -1997,6 +1997,27 @@ They should reschedule and only execute FN after `clutch-db-busy-p' becomes nil.
       (should (string-match-p "ROWNUM <= 80" sql))
       (should (string-match-p "rn > 70" sql)))))
 
+(ert-deftest clutch-db-test-jdbc-build-paged-sql-preserves-user-order-by ()
+  "Generic JDBC pagination should not append a second top-level ORDER BY."
+  (let* ((conn (make-clutch-jdbc-conn :params '(:driver sqlserver)))
+         (sql (clutch-db-build-paged-sql
+               conn
+               "SELECT * FROM t ORDER BY created_at DESC"
+               0 10)))
+    (should (string-match-p "ORDER BY created_at DESC" sql))
+    (should-not (string-match-p "ORDER BY created_at DESC.*ORDER BY" sql))
+    (should (string-match-p "OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY\\'" sql))))
+
+(ert-deftest clutch-db-test-jdbc-build-paged-sql-duckdb-uses-limit-offset ()
+  "DuckDB JDBC pagination should use LIMIT/OFFSET."
+  (let* ((conn (make-clutch-jdbc-conn :params '(:url "jdbc:duckdb:/tmp/test.duckdb")))
+         (sql (clutch-db-build-paged-sql
+               conn
+               "SELECT * FROM t ORDER BY created_at DESC"
+               0 10)))
+    (should (string-match-p "ORDER BY created_at DESC LIMIT 10 OFFSET 0\\'" sql))
+    (should-not (string-match-p "FETCH NEXT" sql))))
+
 ;;;; Unit tests — SQL escaping
 
 (ert-deftest clutch-db-test-mysql-escape ()


### PR DESCRIPTION
Hi,

Great package - it's already in my daily workflow.  I had a few teething issues with DuckDB which had me originally nesting my ORDER BY queries to make them work - but I took a look at the source and have patched what I think is the underlying issue.

This patch fixes a JDBC pagination composition bug and adds a narrow
DuckDB-specific pagination branch.

The broader bug is not DuckDB-specific: the generic non-Oracle JDBC path
could append `ORDER BY (SELECT NULL)` even when the user's SQL already had a
top-level `ORDER BY`, producing invalid SQL with two top-level `ORDER BY`
clauses.

DuckDB was the reproducer for that bug, and DuckDB also prefers
`LIMIT/OFFSET` rather than `OFFSET … FETCH NEXT …`, so the patch adds a
DuckDB JDBC special case using Clutch's existing `LIMIT/OFFSET` helper.

## Problem

Before this change, the generic JDBC pagination path produced SQL like:

```sql
SELECT *
FROM t
ORDER BY created_at DESC
ORDER BY (SELECT NULL)
OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
```

That is invalid because it has two top-level `ORDER BY` clauses.

Clutch does need to control pagination for result browsing, and it should
still take control when the result buffer applies an explicit Clutch sort.
The problem was only the composition of pagination SQL when:

- the backend is using the generic non-Oracle JDBC path, and
- the user query already has a top-level `ORDER BY`, and
- Clutch is not actively replacing that order with a result-buffer sort.

DuckDB additionally wants pagination in this form:

```sql
SELECT *
FROM t
ORDER BY created_at DESC
LIMIT 10 OFFSET 0
```

## What changed

### 1. Generic JDBC fix

The non-Oracle JDBC `OFFSET/FETCH` path now detects an existing top-level
user `ORDER BY`. When Clutch is not applying its own sort, it preserves the
user ordering and does not append `ORDER BY (SELECT NULL)`.

That means generic JDBC now produces:

```sql
SELECT *
FROM t
ORDER BY created_at DESC
OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
```

instead of generating a second top-level `ORDER BY`.

### 2. DuckDB JDBC dialect branch

For `jdbc:duckdb:` URLs, pagination now uses the existing
`clutch-db--build-limit-offset-paged-sql` helper.

That gives DuckDB-native SQL:

```sql
SELECT *
FROM t
ORDER BY created_at DESC
LIMIT 10 OFFSET 0
```

## Scope

This patch intentionally keeps the `LIMIT/OFFSET` override narrow.

`LIMIT/OFFSET` is not DuckDB-specific as a SQL idiom; other JDBC backends may
also belong to that dialect family. But this patch only applies the dialect
override to DuckDB because that is the confirmed reproducer. Broadening the
JDBC dialect split should be a follow-up once additional backends are
identified and tested.

So the intended framing is:

- generic fix: avoid duplicating top-level `ORDER BY` in JDBC pagination
- narrow dialect fix: use `LIMIT/OFFSET` for DuckDB JDBC

## Tests

Added focused unit coverage for:

- preserving a user top-level `ORDER BY` on generic JDBC
- using `LIMIT/OFFSET` for DuckDB JDBC
- preserving the existing explicit-offset coverage

Local verification:

- focused JDBC paging ERT tests passed
- `clutch-db-jdbc.el` byte-compiled cleanly

## Future direction

This likely points toward a small JDBC pagination dialect layer:

- `LIMIT/OFFSET` family: DuckDB, and potentially other JDBC backends
- `OFFSET/FETCH` family: SQL Server, DB2, and similar
- Oracle `ROWNUM` path: existing special case

This patch does not try to solve that whole design space. It fixes the
confirmed generic composition bug and adds the narrow DuckDB branch needed for
the reproduced case.