### PR TITLE
feat: When copying the result as an org table, align the table

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -512,7 +512,7 @@ on public `M-x` entry points and named commands that users may call directly.
 | `clutch-result-first-page` / `clutch-result-last-page` | Jump to the first page / last row window |
 | `clutch-result-next-cell` / `clutch-result-prev-cell` | Move across cells |
 | `clutch-result-down-cell` / `clutch-result-up-cell` | Move down/up within the current column |
-| `clutch-result-copy-tsv` / `clutch-result-copy-csv` / `clutch-result-copy-org-table` | Copy the current cell/selection as TSV / CSV / Org table |
+| `clutch-result-copy-tsv` / `clutch-result-copy-csv` / `clutch-result-copy-org-table` | Copy the current cell/selection as TSV / CSV / aligned Org table |
 | `clutch-result-copy-insert` / `clutch-result-copy-update` | Copy rows as INSERT / UPDATE statements |
 | `clutch-result-copy-dispatch` | Open the copy transient |
 | `clutch-result-export` | Export all rows as CSV / INSERT / UPDATE (copy or file) |

--- a/clutch-result.el
+++ b/clutch-result.el
@@ -165,6 +165,7 @@ Each element corresponds to the same-index column.  Nil when unavailable.")
                   (conn table col-names &optional load))
 (declare-function clutch--status-separator "clutch-ui" ())
 (declare-function clutch-preview-execution-sql "clutch-query" ())
+(declare-function org-table-align "org-table")
 
 ;;;; Result buffer lifecycle
 
@@ -2812,8 +2813,21 @@ rectangle and inactive regions fall back to the current cell."
                    for vals = (mapcar (lambda (i) (nth i row)) col-indices)
                    collect (mapconcat #'clutch--csv-escape vals ",")))))
 
+(defun clutch--org-table-align-lines (lines)
+  "Return LINES aligned the way `org-table-align' renders an Org table.
+If Org is unavailable, return LINES unchanged rather than signaling."
+  (if (not (require 'org-table nil t))
+      lines
+    (with-temp-buffer
+      (delay-mode-hooks (org-mode))
+      (insert (mapconcat #'identity lines "\n"))
+      (goto-char (point-min))
+      (org-table-align)
+      (split-string (buffer-substring-no-properties (point-min) (point-max))
+                    "\n" t))))
+
 (defun clutch--org-table-lines-for-rows (rows col-indices)
-  "Return Org table lines for ROWS using COL-INDICES."
+  "Return aligned Org table lines for ROWS using COL-INDICES."
   (cl-labels
       ((cell (val)
          (let ((s (clutch--format-value val)))
@@ -2827,12 +2841,13 @@ rectangle and inactive regions fall back to the current cell."
                     (mapconcat #'identity
                                (make-list (length col-indices) "---")
                                "+"))))
-      (cons (table-row col-names)
-            (cons separator
-	                  (cl-loop for row in rows
-	                           for vals = (mapcar (lambda (i) (nth i row))
-	                                              col-indices)
-	                           collect (table-row vals)))))))
+      (clutch--org-table-align-lines
+       (cons (table-row col-names)
+             (cons separator
+                   (cl-loop for row in rows
+                            for vals = (mapcar (lambda (i) (nth i row))
+                                               col-indices)
+                            collect (table-row vals))))))))
 
 ;;;; Export commands
 

--- a/test/clutch-test.el
+++ b/test/clutch-test.el
@@ -6441,7 +6441,7 @@ SPEC has the form (VAR COLUMNS COLUMN-DEFS . LOCALS)."
 (ert-deftest clutch-test-copy-format-commands-copy-visible-content ()
   "Public CSV and TSV copy commands should copy through the real entry point."
   (dolist (case '((clutch-result-copy-csv "name\nalice")
-                  (clutch-result-copy-org-table "| name |\n|---|\n| alice |")
+                  (clutch-result-copy-org-table "| name  |\n|-------|\n| alice |")
                   (clutch-result-copy-tsv "alice")))
     (pcase-let ((`(,command ,expected-text) case))
       (ert-info ((symbol-name command))
@@ -6494,8 +6494,19 @@ SPEC has the form (VAR COLUMNS COLUMN-DEFS . LOCALS)."
                 ((symbol-function 'clutch-result--region-rectangle-indices)
                  (lambda () '((0 1) 0 1))))
         (clutch-result-copy 'org-table)
-        (should (equal (current-kill 0)
-                       "| name | note |\n|---+---|\n| alice | a\\vertb |\n| bob | x\\ny |"))))))
+        (let ((result (current-kill 0)))
+          ;; Verify content is preserved and alignment is applied.
+          (should (string-match-p "a\\\\vert" result))
+          (should (string-match-p "x\\\\n" result))
+          (let ((lines (split-string result "\n")))
+            (should (= (length lines) 4))
+            ;; All lines must have equal length (aligned column separators).
+            (should (apply #'= (mapcar #'length lines)))
+            (should (equal result
+                           (concat "| name  | note    |\n"
+                                   "|-------+---------|\n"
+                                   "| alice | a\\vertb |\n"
+                                   "| bob   | x\\ny    |")))))))))
 
 (ert-deftest clutch-test-copy-csv-via-unified-entry-uses-region-rectangle ()
   "Unified CSV copy should use rectangle row/column bounds when region is active."


### PR DESCRIPTION
Hey, great package! It is now my daily driver for SQL queries 👍 

One thing I noticed is that when you're in the result buffer and copy the result to an org table, the that the table isn't aligned. That's perfectly fine if you just want to paste it into an org buffer, but what I want to do is to show other people and paste it into a Slack channel or similar.

This PR fixes that by aligning the org table before copying it.

(I thought of putting this behind a config var, but it seems to be a strict improvement. It's still a valid org table, and it's human readable)

First time doing anything in this repo, so please let me know if I've missed anything with your development process, or if you have any other objections to the code.