### PR TITLE
feat: When copying the result as an org table, align the table

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -512,7 +512,7 @@ on public `M-x` entry points and named commands that users may call directly.
 | `clutch-result-first-page` / `clutch-result-last-page` | Jump to the first page / last row window |
 | `clutch-result-next-cell` / `clutch-result-prev-cell` | Move across cells |
 | `clutch-result-down-cell` / `clutch-result-up-cell` | Move down/up within the current column |
-| `clutch-result-copy-tsv` / `clutch-result-copy-csv` / `clutch-result-copy-org-table` | Copy the current cell/selection as TSV / CSV / Org table |
+| `clutch-result-copy-tsv` / `clutch-result-copy-csv` / `clutch-result-copy-org-table` | Copy the current cell/selection as TSV / CSV / aligned Org table |
 | `clutch-result-copy-insert` / `clutch-result-copy-update` | Copy rows as INSERT / UPDATE statements |
 | `clutch-result-copy-dispatch` | Open the copy transient |
 | `clutch-result-export` | Export all rows as CSV / INSERT / UPDATE (copy or file) |

--- a/clutch-result.el
+++ b/clutch-result.el
@@ -165,6 +165,7 @@ Each element corresponds to the same-index column.  Nil when unavailable.")
                   (conn table col-names &optional load))
 (declare-function clutch--status-separator "clutch-ui" ())
 (declare-function clutch-preview-execution-sql "clutch-query" ())
+(declare-function org-table-align "org-table")
 
 ;;;; Result buffer lifecycle
 
@@ -2812,8 +2813,21 @@ rectangle and inactive regions fall back to the current cell."
                    for vals = (mapcar (lambda (i) (nth i row)) col-indices)
                    collect (mapconcat #'clutch--csv-escape vals ",")))))
 
+(defun clutch--org-table-align-lines (lines)
+  "Return LINES aligned the way `org-table-align' renders an Org table.
+If Org is unavailable, return LINES unchanged rather than signaling."
+  (if (not (require 'org-table nil t))
+      lines
+    (with-temp-buffer
+      (delay-mode-hooks (org-mode))
+      (insert (mapconcat #'identity lines "\n"))
+      (goto-char (point-min))
+      (org-table-align)
+      (split-string (buffer-substring-no-properties (point-min) (point-max))
+                    "\n" t))))
+
 (defun clutch--org-table-lines-for-rows (rows col-indices)
-  "Return Org table lines for ROWS using COL-INDICES."
+  "Return aligned Org table lines for ROWS using COL-INDICES."
   (cl-labels
       ((cell (val)
          (let ((s (clutch--format-value val)))
@@ -2827,12 +2841,13 @@ rectangle and inactive regions fall back to the current cell."
                     (mapconcat #'identity
                                (make-list (length col-indices) "---")
                                "+"))))
-      (cons (table-row col-names)
-            (cons separator
-	                  (cl-loop for row in rows
-	                           for vals = (mapcar (lambda (i) (nth i row))
-	                                              col-indices)
-	                           collect (table-row vals)))))))
+      (clutch--org-table-align-lines
+       (cons (table-row col-names)
+             (cons separator
+                   (cl-loop for row in rows
+                            for vals = (mapcar (lambda (i) (nth i row))
+                                               col-indices)
+                            collect (table-row vals))))))))
 
 ;;;; Export commands
 

--- a/test/clutch-test.el
+++ b/test/clutch-test.el
@@ -6441,7 +6441,7 @@ SPEC has the form (VAR COLUMNS COLUMN-DEFS . LOCALS)."
 (ert-deftest clutch-test-copy-format-commands-copy-visible-content ()
   "Public CSV and TSV copy commands should copy through the real entry point."
   (dolist (case '((clutch-result-copy-csv "name\nalice")
-                  (clutch-result-copy-org-table "| name |\n|---|\n| alice |")
+                  (clutch-result-copy-org-table "| name  |\n|-------|\n| alice |")
                   (clutch-result-copy-tsv "alice")))
     (pcase-let ((`(,command ,expected-text) case))
       (ert-info ((symbol-name command))
@@ -6494,8 +6494,19 @@ SPEC has the form (VAR COLUMNS COLUMN-DEFS . LOCALS)."
                 ((symbol-function 'clutch-result--region-rectangle-indices)
                  (lambda () '((0 1) 0 1))))
         (clutch-result-copy 'org-table)
-        (should (equal (current-kill 0)
-                       "| name | note |\n|---+---|\n| alice | a\\vertb |\n| bob | x\\ny |"))))))
+        (let ((result (current-kill 0)))
+          ;; Verify content is preserved and alignment is applied.
+          (should (string-match-p "a\\\\vert" result))
+          (should (string-match-p "x\\\\n" result))
+          (let ((lines (split-string result "\n")))
+            (should (= (length lines) 4))
+            ;; All lines must have equal length (aligned column separators).
+            (should (apply #'= (mapcar #'length lines)))
+            (should (equal result
+                           (concat "| name  | note    |\n"
+                                   "|-------+---------|\n"
+                                   "| alice | a\\vertb |\n"
+                                   "| bob   | x\\ny    |")))))))))
 
 (ert-deftest clutch-test-copy-csv-via-unified-entry-uses-region-rectangle ()
   "Unified CSV copy should use rectangle row/column bounds when region is active."


### PR DESCRIPTION
Reopening since https://github.com/LuciusChen/clutch/pull/26 was closed.

I looked at your response there, and I have a couple of follow up comments:

> For targets like Discord/Slack normal messages, the copied table still does not visually align because those clients don’t render plain text as a fixed-width Org table. So the benefit seems limited to plaintext/monospace paste targets, while the change also alters the default copied output and adds an Org alignment step to the copy path.

I'm not sure I understand this comment. "the copied table still does not visually align because those clients don’t render plain text as a fixed-width Org table"

E.g. Slack does render it as fixed-width when you put the text in a code block. This is what you normally to do when you share code and text like this. In Slack you just type three backticks to open a code block. I do this pretty much every day using my local branch to copy the result, so this workflow is useful.

One comment on the `org-mode` usage, which I noticed myself just earlier today when I did copy the result to put it in an org buffer.

Yes, the table _can_ be aligned manually with C-c C-c, but... why should you _manually_ need to do that? When you copy the result as an org-table, the aim is to put it in an org buffer. Why involve another manual step to make it look nice when you don't need to?

If you still think this needs to go behind a customize variable, I can do that too. Please let me know.